### PR TITLE
Minor fix for Instance.pm

### DIFF
--- a/lib/VM/EC2/Instance.pm
+++ b/lib/VM/EC2/Instance.pm
@@ -494,28 +494,28 @@ sub valid_fields {
               placement
               kernelId
               ramdiskId
+              platform
               monitoring
+              subnetId
+              vpcId
               privateIpAddress
               ipAddress
               sourceDestCheck
+              networkInterfaceSet
+              iamInstanceProfile
+              ebsOptimized
+              groupSet
+              stateReason
               architecture
               rootDeviceType
               rootDeviceName
               blockDeviceMapping
-              instanceLifecycle
+              instanceLifeCycle
               spotInstanceRequestId
               virtualizationType
               clientToken
               hypervisor
               tagSet
-              platform
-              ebsOptimized
-              networkInterfaceSet
-              iamInstanceProfile
-              vpcId
-              subnetId
-              stateReason
-              instanceLifeCycle
              );
 }
 


### PR DESCRIPTION
valid_fields was missing groupSet.  instanceLifeCycle had a typo that I missed before and I had added it again.  I reordered the list to match the documentation.
