### PR TITLE
Fixes for security groups

### DIFF
--- a/lib/VM/EC2/SecurityGroup.pm
+++ b/lib/VM/EC2/SecurityGroup.pm
@@ -262,21 +262,6 @@ sub ipPermissionsEgress {
     return @p;
 }
 
-# generate a hash of the ingress permissions, for use in modification
-sub _ingress_permissions {
-    my $self = shift;
-    return $self->{_ingress_permissions} if exists $self->{_ingress_permissions};
-    my %h = map {("$_" => $_)} $self->ipPermissions;
-    return $self->{_ingress_permissions} = \%h;
-}
-
-sub _egress_permissions {
-    my $self = shift;
-    return $self->{_egress_permissions} if exists $self->{_egress_permissions};
-    my %h = map {("$_" => $_)} $self->ipPermissionsEgress;
-    return $self->{_egress_permissions} = \%h;
-}
-
 sub _uncommitted_permissions {
     my $self = shift;
     my ($action,$direction) = @_;   # e.g. 'Authorize','Ingress'
@@ -287,14 +272,12 @@ sub _uncommitted_permissions {
 sub authorize_incoming {
     my $self = shift;
     my $permission = $self->_new_permission(@_);
-    return if $self->_ingress_permissions->{$permission};  # already defined
     $self->{uncommitted}{Authorize}{Ingress}{$permission}=$permission;
 }
 
 sub authorize_outgoing {
     my $self = shift;
     my $permission = $self->_new_permission(@_);
-    return if $self->_egress_permissions->{$permission};  # already defined
     $self->{uncommitted}{Authorize}{Egress}{$permission}=$permission;
 }
 
@@ -304,7 +287,6 @@ sub revoke_incoming {
     if ($self->{uncommitted}{Authorize}{Ingress}{$permission}) {
 	delete $self->{uncommitted}{Authorize}{Ingress}{$permission};
     }
-    return unless $self->_ingress_permissions->{$permission};
     $self->{uncommitted}{Revoke}{Ingress}{$permission}=$permission;
 }
 
@@ -314,7 +296,6 @@ sub revoke_outgoing {
     if ($self->{uncommitted}{Authorize}{Egress}{$permission}) {
 	delete $self->{uncommitted}{Authorize}{Egress}{$permission};
     }
-    return unless $self->_egress_permissions->{$permission};
     $self->{uncommitted}{Revoke}{Egress}{$permission}=$permission;
 }
 

--- a/lib/VM/EC2/SecurityGroup/IpPermission.pm
+++ b/lib/VM/EC2/SecurityGroup/IpPermission.pm
@@ -59,9 +59,8 @@ sub valid_fields {
 
 sub short_name {
     my $s = shift;
-    my $from = $s->ipRanges ? ' FROM CIDR '.join(',',sort $s->ipRanges)
-              :$s->groups   ? ' GRPNAME '.join(',',  sort $s->groups)
-              :''; 
+    my $from = ($s->ipRanges && (' FROM CIDR '.join(',',sort $s->ipRanges))) .
+               ($s->groups && (' GRPNAME '.join(',',  sort $s->groups)));
     sprintf("%s(%s..%s)%s",$s->ipProtocol,$s->fromPort,$s->toPort,$from);
 }
 


### PR DESCRIPTION
 remove existence checks from SecurityGroup.pm as they do not work when a rule has multiple IPs/groups

fix shot_name() in IpPermission.pm - a Protocol(From..To) combination can have both IP-based and group-based rules
