### PR TITLE
AWS Security Token feature working again

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -18,9 +18,7 @@ my $build = Module::Build->new(
       'XML::Simple'  => '2.18',
       'File::Path'   => '2.08',
       'String::Approx' => '3.26',
-    },
-    recommends        => {
-	'JSON'      => 0,
+      'JSON'         => 0,
     },
     build_class        => 'Module::Build',
     );


### PR DESCRIPTION
Hi,

The Policy module was generating the JSON manually and the feature was not working. I have made it use the JSON module in order to encode the policy before signing and sending it.

Tests have been also adapted to the new way of generate the policies. JSON module has been added as a dependency rather than a recommendation.

Hope you accept it. If you would prefer anything in some other way, don't hesitate to request it :)

Regards,
Miquel Ruiz
