### PR TITLE
API 2013-02-01

### DIFF
--- a/lib/VM/EC2/BlockDevice/Attachment.pm
+++ b/lib/VM/EC2/BlockDevice/Attachment.pm
@@ -123,8 +123,9 @@ sub current_status {
 sub refresh {
     my $self = shift;
     my $v    = $self->aws->describe_volumes($self->volumeId);
-    my $a    = $v->attachment;
-    %$self   = %$a;
+    my $a    = $v && $v->attachment;
+    %$self   = %$a if $a;
+    return defined $a;
 }
 
 sub deviceName { shift->device }

--- a/lib/VM/EC2/Dispatch.pm
+++ b/lib/VM/EC2/Dispatch.pm
@@ -172,7 +172,8 @@ use constant ObjectRegistration => {
             $image;
         };
     },
-    DeregisterImage      => 'boolean',
+    DeregisterImage   => 'boolean',
+    CopyImage         => sub { shift->{imageId} },
     DescribeAddresses => 'fetch_items,addressesSet,VM::EC2::ElasticAddress',
     AssociateAddress  => sub {
 	my $data = shift;
@@ -220,6 +221,7 @@ use constant ObjectRegistration => {
     CreateVpc                         => 'fetch_one,vpc,VM::EC2::VPC',
     DescribeVpcs                      => 'fetch_items,vpcSet,VM::EC2::VPC',
     DeleteVpc                         => 'boolean',
+    ModifyVpcAttribute                => 'boolean',
     # dhcp options
     DescribeDhcpOptions               => 'fetch_items,dhcpOptionsSet,VM::EC2::VPC::DhcpOptions,nokey',
     CreateDhcpOptions                 => 'fetch_one,dhcpOptions,VM::EC2::VPC::DhcpOptions,nokey',
@@ -283,7 +285,7 @@ use constant ObjectRegistration => {
     EnableVgwRoutePropagation         => 'boolean',
     # elastic load balancers
     DescribeLoadBalancers             => 'fetch_members,LoadBalancerDescriptions,VM::EC2::ELB',
-    ConfigureHealthCheck              => 'elb_fetch_one,HealthCheck,VM::EC2::ELB::HealthCheck',
+    ConfigureHealthCheck              => 'fetch_one_result,HealthCheck,VM::EC2::ELB::HealthCheck',
     CreateAppCookieStickinessPolicy   => sub { exists shift->{CreateAppCookieStickinessPolicyResult} },
     CreateLBCookieStickinessPolicy    => sub { exists shift->{CreateLBCookieStickinessPolicyResult} },
     CreateLoadBalancer                => sub { shift->{CreateLoadBalancerResult}{DNSName} },
@@ -325,6 +327,7 @@ sub response2objects {
 
     my $handler    = $self->class_from_response($response) or return;
     my $content  = $response->decoded_content;
+#print $content,"\n";
 
     my ($method,@params) = split /,/,$handler;
 
@@ -458,9 +461,9 @@ sub elb_member_list {
                            @{$parsed->{$result_key}{$tag}{member}};
 }
 
-# identical to fetch_one, except looks inside the *Result tag that ELB API calls
-# return
-sub elb_fetch_one {
+# identical to fetch_one, except looks inside the (APICallName)Result tag that
+# ELB and RDS API calls return
+sub fetch_one_result {
     my $self = shift;
     my ($content,$ec2,$tag,$class,$nokey) = @_; 
     load_module($class);
@@ -594,6 +597,16 @@ sub create_error_object {
     eval "require $class; 1" || die $@ unless $class->can('new');
     my $parsed = $self->new_xml_parser->XMLin($content);
     return $class->new($parsed->{Errors}{Error},$ec2,@{$parsed}{'xmlns','requestId'});
+}
+
+# alternate method used for ELB, RDS calls
+sub create_alt_error_object {
+    my $self = shift;
+    my ($content,$ec2) = @_;
+    my $class   = ObjectRegistration->{Error};
+    eval "require $class; 1" || die $@ unless $class->can('new');
+    my $parsed = $self->new_xml_parser->XMLin($content);
+    return $class->new($parsed->{Error},$ec2,@{$parsed}{'xmlns','requestId'});
 }
 
 # not a method!

--- a/lib/VM/EC2/ElasticAddress.pm
+++ b/lib/VM/EC2/ElasticAddress.pm
@@ -103,8 +103,9 @@ sub disassociate {
 
 sub refresh {
     my $self = shift;
-    my $i  = $self->aws->describe_addresses($self) or return;
-    %$self = %$i;
+    my $i  = $self->aws->describe_addresses($self);
+    %$self = %$i if $i;
+    return defined $i;
 }
 
 1;

--- a/lib/VM/EC2/Image.pm
+++ b/lib/VM/EC2/Image.pm
@@ -181,7 +181,21 @@ privileges to the owner only.
 
 See also authorized_users().
 
+=head2 $copy = $image->copy(-region => $region, -name => $name, -description => $desc)
 
+Copies the image to another region.
+
+Required arguments:
+
+ -region           The region to copy to
+
+Optional arguments:
+
+ -name             The name of the image.
+
+ -description      The description of the image.
+
+ -client_token     Unique identifier to ensure idempotency of the request
 
 =head2 $image->refresh
 
@@ -319,7 +333,25 @@ sub refresh {
     my $self = shift;
     my $i   = shift;
     ($i) = $self->aws->describe_images(-image_id=>$self->imageId) unless $i;
-    %$self  = %$i;
+    %$self  = %$i if $i;
+    return defined $i;
+}
+
+sub copy {
+    my $self = shift;
+    my %args = @_;
+    my $image_id = $self->imageId;
+    my $name = $args{-name};
+    my $desc = $args{-description} || $args{-desc};
+    my $token = $args{-client_token} || $args{-token};
+    my $region = $args{-region} or croak "copy(): -region argument required";
+    my $orig_region = $self->aws->region;
+    # set region to dest region in ec2 object
+    $self->aws->region($region);
+    my $image = $self->aws->copy_image(-source_region=>$orig_region, -source_image_id=>$image_id, -name => $name, -description=>$desc, -client_token => $token);
+    # set region back
+    $self->aws->region($orig_region);
+    return $image;
 }
 
 1;

--- a/lib/VM/EC2/Instance.pm
+++ b/lib/VM/EC2/Instance.pm
@@ -767,7 +767,8 @@ sub refresh {
     my $self = shift;
     my $i   = shift;
     ($i) = $self->aws->describe_instances(-instance_id=>$self->instanceId) unless $i;
-    %$self  = %$i;
+    %$self  = %$i if $i;
+    return defined $i;
 }
 
 sub console_output {

--- a/lib/VM/EC2/NetworkInterface.pm
+++ b/lib/VM/EC2/NetworkInterface.pm
@@ -206,7 +206,8 @@ sub refresh {
     my $self = shift;
     my $i    = shift;
     ($i) = $self->aws->describe_network_interfaces(-network_interface_id=>$self->networkInterfaceId) unless $i;
-    %$self  = %$i;
+    %$self  = %$i if $i;
+    return defined $i;
 }
 
 sub current_status {

--- a/lib/VM/EC2/ReservedInstance.pm
+++ b/lib/VM/EC2/ReservedInstance.pm
@@ -129,9 +129,9 @@ sub current_state { shift->current_status } # alias
 
 sub refresh {
     my $self = shift;
-    my $i = $self->ec2->describe_reserved_instances($self->reservedInstancesId)
-	or die $self->ec2->error_str;
-    %$self  = %$i;
+    my $i = $self->ec2->describe_reserved_instances($self->reservedInstancesId);
+    %$self = %$i if $i;
+    return defined $i;
 }
 
 

--- a/lib/VM/EC2/SecurityGroup.pm
+++ b/lib/VM/EC2/SecurityGroup.pm
@@ -313,8 +313,9 @@ sub write { shift->update }
 
 sub refresh {
     my $self = shift;
-    my $i    = $self->aws->describe_security_groups($self->groupId) or return;
-    %$self   = %$i;
+    my $i    = $self->aws->describe_security_groups($self->groupId);
+    %$self   = %$i if $i;
+    return defined $i;
 }
 
 sub _new_permission {

--- a/lib/VM/EC2/Spot/InstanceRequest.pm
+++ b/lib/VM/EC2/Spot/InstanceRequest.pm
@@ -146,7 +146,8 @@ sub fault {
 sub refresh {
     my $self = shift;
     my $r    = $self->ec2->describe_spot_instance_requests($self->spotInstanceRequestId);
-    %$self   = %$r;
+    %$self   = %$r if $r;
+    return defined $r;
 }
 
 sub current_status {

--- a/lib/VM/EC2/VPC.pm
+++ b/lib/VM/EC2/VPC.pm
@@ -98,7 +98,8 @@ sub refresh {
     my $self = shift;
     my $i   = shift;
     ($i) = $self->aws->describe_vpcs(-vpc_id=>$self->vpcId) unless $i;
-    %$self  = %$i;
+    %$self = %$i if $i;
+    return defined $i;
 }
 
 sub current_state {

--- a/lib/VM/EC2/VPC/InternetGateway.pm
+++ b/lib/VM/EC2/VPC/InternetGateway.pm
@@ -104,7 +104,8 @@ sub refresh {
     my $self = shift;
     my $i   = shift;
     ($i) = $self->aws->describe_internet_gateways($self->internetGatewayId) unless $i;
-    %$self  = %$i;
+    %$self  = %$i if $i;
+    return defined $i;
 }
 
 1;

--- a/lib/VM/EC2/VPC/RouteTable.pm
+++ b/lib/VM/EC2/VPC/RouteTable.pm
@@ -130,7 +130,8 @@ sub refresh {
     my $self = shift;
     my $i   = shift;
     ($i) = $self->aws->describe_subnets($self->subnetId) unless $i;
-    %$self  = %$i;
+    %$self  = %$i if $i;
+    return defined $i;
 }
 
 sub create_route {

--- a/lib/VM/EC2/VPC/Subnet.pm
+++ b/lib/VM/EC2/VPC/Subnet.pm
@@ -115,7 +115,8 @@ sub refresh {
     my $self = shift;
     my $i   = shift;
     ($i) = $self->aws->describe_subnets($self->subnetId) unless $i;
-    %$self  = %$i;
+    %$self  = %$i if $i;
+    return defined $i;
 }
 
 sub current_state {

--- a/lib/VM/EC2/Volume.pm
+++ b/lib/VM/EC2/Volume.pm
@@ -266,7 +266,8 @@ sub current_status {
 sub refresh {
     my $self = shift;
     my $v    = $self->aws->describe_volumes($self->volumeId);
-    %$self   = %$v;
+    %$self   = %$v if $v;
+    return defined $v;
 }
 
 sub auto_enable_io {


### PR DESCRIPTION
Hi Lincoln,

Here's a quick update for the 2013-02-01 API functions.

When using the CopyImage call, if you run a DescribeImages on the AMI being copied, the snapshot IDs are not listed in the result until the copy is complete.  I opened a ticket with AWS requesting this be changed and they report that it has been sent to the engineering team for implementation -- good news.  Without this it is impossible to automate a way to determine progress of the copy.

I'm holding off on RDS until you publish the refactored code -- I figure it will be a lot easier for you to merge that way.
