### PR TITLE
Argument missing in update_autoscaling_group

### DIFF
--- a/lib/VM/EC2/REST/autoscaling.pm
+++ b/lib/VM/EC2/REST/autoscaling.pm
@@ -260,6 +260,7 @@ Optional arguments:
   -desired_capacity
   -health_check_type
   -health_check_grace_period
+  -launch_configuration_name
   -placement_group
   -vpc_zone_identifier
   -max_size
@@ -281,7 +282,8 @@ sub update_autoscaling_group {
 
     my @p = map {$self->single_parm($_,\%args) }
        qw( DefaultCooldown DesiredCapacity HealthCheckGracePeriod
-           HealthCheckType PlacementGroup VPCZoneIdentifier MaxSize MinSize );
+           HealthCheckType LaunchConfigurationName PlacementGroup
+           VPCZoneIdentifier MaxSize MinSize );
     push @params, @p;
 
     return $self->asg_call('UpdateAutoScalingGroup',@params);


### PR DESCRIPTION
Hello,

The LaunchConfigurationName argument was missing, making impossible to modify it in an existing autoscaling group.

Regards,
Miquel Ruiz
