### PR TITLE
Modifying to support instances with >10 disks.

### DIFF
--- a/lib/VM/EC2/ParmParser.pm
+++ b/lib/VM/EC2/ParmParser.pm
@@ -179,7 +179,7 @@ sub block_device_parm {
 	}
 	elsif ($blockdevice eq 'none') {
 	    push @p,("$argname.$c.NoDevice" => '');
-	} elsif ($blockdevice =~ /^ephemeral\d$/) {
+	} elsif ($blockdevice =~ /^ephemeral\d+$/) {
 	    push @p,("$argname.$c.VirtualName"=>$blockdevice);
 	} else {
 	    my ($snapshot,$size,$delete_on_term,$vtype,$iops) = split ':',$blockdevice;


### PR DESCRIPTION
Without this change, ephemeral disks with 2 trailing digits don't match the ephemeral\d$ pattern, and therefore, an attempt is made to initialize them through the EBS code path instead, causing errors.
